### PR TITLE
travis.yml: Add travis-ci to kernel for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: GPL-2.0+
+# Copyright (C) 2019 Texas Instruments Incorporated - http://www.ti.com/
+
+# build Linux Kernel on Travis CI - https://travis-ci.org/
+# Abstracted from uBoot travis.yml (Why reinvent the wheel?)
+
+language: c
+sudo: required
+dist: bionic
+
+addons:
+  apt:
+    packages:
+    - bison
+    - flex
+    - cppcheck
+    - sparse
+    - bc
+    - swig
+    - device-tree-compiler
+    - lzop
+    - liblz4-tool
+    - lzma-alone
+    - libisl15
+    - libelf-dev
+
+install:
+  - sudo apt-get update -qq
+
+env:
+  global:
+    - export BUILD_THREADS=$(grep "^processor" /proc/cpuinfo | wc -l)
+    - export EXTRA_FLAGS="CONFIG_COMPLIE_TEST=y CONFIG_GENERIC_COMPAT_VDSO=n "
+    - export COCCI_BUILD="coccicheck MODE=report J=4"
+
+before_script:
+  - if [[ "${TRAVIS_BRANCH}" != ${TARGET_BRANCH} ]]; then exit 0 ; fi
+  - mkdir -p toolchain
+  - cd toolchain
+  - if [[ "${TOOLCHAIN}" == arm ]]; then
+     wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz &&
+     tar xf gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz;
+   fi
+  - if [[ "${TOOLCHAIN}" == arm64 ]]; then
+      wget https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz &&
+      tar xf gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz;
+    fi
+  - if [[ "${TOOLCHAIN}" == x86_64 ]]; then
+      wget https://mirrors.edge.kernel.org/pub/tools/crosstool/files/bin/x86_64/8.1.0/x86_64-gcc-8.1.0-nolibc-x86_64-linux.tar.gz &&
+      tar xf x86_64-gcc-8.1.0-nolibc-x86_64-linux.tar.gz;
+    fi
+  - cd ..;
+  - if [[ ! -z ${COCCI_MODULE} ]]; then
+     sudo add-apt-repository --yes ppa:npalix/coccinelle;
+     sudo apt-get update;
+     sudo apt-get install coccinelle;
+     sudo apt-get build-dep coccinelle;
+    fi
+
+
+script:
+  - if [[ "${TOOLCHAIN}" == arm64 ]]; then
+     export ARCH=arm64;
+     export CROSS_COMPILE=$PWD/toolchain/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/bin/aarch64-linux-gnu-;
+     export DEFCONFIG="defconfig";
+    fi
+  - if [[ "${TOOLCHAIN}" == arm ]]; then
+     export ARCH=arm;
+     export CROSS_COMPILE=$PWD/toolchain/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/bin/arm-linux-gnueabihf-;
+     export DEFCONFIG="multi_v7_defconfig";
+    fi
+  - if [[ "${TOOLCHAIN}" == x86_64 ]]; then
+     export CROSS_COMPILE=$PWD/toolchain/gcc-8.1.0-nolibc/x86_64-linux/bin/x86_64-linux-;
+     export DEFCONFIG="x86_64_defconfig";
+    fi
+  - make -j${BUILD_THREADS} mrproper;
+  - make -j${BUILD_THREADS} ${DEFCONFIG};
+  - make -j${BUILD_THREADS} ${EXTRA_FLAGS} ${TARGET_MODULE} 2>error_log;
+  - ERROR_OUT=$(wc -l error_log | awk '{print$1}');
+  - if [[ ${ERROR_OUT} -gt 0 ]]; then cat error_log; exit 1; fi
+  - if [[ ! -z ${COCCI_MODULE} ]]; then
+     make -j${BUILD_THREADS} mrproper;
+     make -j${BUILD_THREADS} ${DEFCONFIG};
+     make -j${BUILD_THREADS} ${EXTRA_FLAGS} ${COCCI_BUILD} ${COCCI_MODULE} >&1 | tee cocci_log;
+     ERROR_OUT=$(grep -wic 'WARNING:\|ERROR:' cocci_log);
+     if [[ ${ERROR_OUT} -gt 0 ]]; then echo "Found coccinelle warnings"; cat cocci_log; exit 1; fi
+    fi
+
+matrix:
+  include:
+  # we need to build by vendor due to 50min time limit for builds
+  # each env setting here is a dedicated build
+    - name: "Checkpatch"
+      env:
+        - TARGET_BRANCH="travis_baseline"
+      script:
+        - mkdir checkpatch_dir
+        - git format-patch ${TRAVIS_COMMIT_RANGE} -o checkpatch_dir
+        - ./scripts/checkpatch.pl --strict checkpatch_dir/*
+    - name: "arm full build"
+      env:
+        - TOOLCHAIN="arm"
+          TARGET_BRANCH="master"
+    - name: "arm64 full build"
+      env:
+        - TOOLCHAIN="arm64"
+          TARGET_BRANCH="master"
+    - name: "x86_64 full build"
+      env:
+        - TOOLCHAIN="x86_64"
+          TARGET_BRANCH="master"
+    - name: "drm bridge partial"
+      env:
+        - TOOLCHAIN="arm64"
+          TARGET_BRANCH="travis_baseline"
+          TARGET_MODULE="drivers/gpu/drm/bridge/"
+          COCCI_MODULE="M=drivers/gpu/drm/bridge/"
+    - name: "phy ti partial"
+      env:
+        - TOOLCHAIN="arm64"
+          TARGET_BRANCH="travis_baseline"
+          TARGET_MODULE="drivers/phy/ti/"
+          COCCI_MODULE="M=drivers/phy/ti/"
+    - name: "Cadence partial"
+      env:
+        - TOOLCHAIN="arm64"
+          TARGET_BRANCH="travis_baseline"
+          TARGET_MODULE="drivers/phy/cadence/"
+          COCCI_MODULE="M=drivers/phy/cadence/"
+    - name: "USB partial"
+      env:
+        - TOOLCHAIN="arm64"
+          TARGET_BRANCH="travis_baseline"
+          TARGET_MODULE="drivers/usb/"
+          COCCI_MODULE="M=drivers/usb/"


### PR DESCRIPTION
Add the travis.yml to the kernel

Goals of the testing:
- Build arm, arm64 and x86_64
- Pull appropriate toolchains

Signed-off-by: Dan Murphy <dmurphy@ti.com>