### PR TITLE
drm/bridge: cdns-mhdp: Add framework to perform platform specific ope…

### DIFF
--- a/drivers/gpu/drm/bridge/cdns-mhdp.c
+++ b/drivers/gpu/drm/bridge/cdns-mhdp.c
@@ -31,6 +31,7 @@
 
 #include <linux/irq.h>
 #include <linux/of_irq.h>
+#include <linux/of_device.h>
 
 #include <asm/unaligned.h>
 
@@ -534,8 +535,15 @@ err_adjust_lt:
 
 #define CDNS_KEEP_ALIVE_TIMEOUT			2000
 
+static const struct mhdp_ops mhdp_ti_ops = {
+	.init = cdns_mhdp_j721e_init,
+	.exit = cdns_mhdp_j721e_fini,
+	.enable = cdns_mhdp_j721e_enable,
+	.disable = cdns_mhdp_j721e_disable,
+};
+
 static const struct of_device_id mhdp_ids[] = {
-	{ .compatible = "cdns,mhdp8546", },
+	{ .compatible = "cdns,mhdp8546", .data = (void *)&mhdp_ti_ops },
 	{ /* sentinel */ }
 };
 MODULE_DEVICE_TABLE(of, mhdp_ids);
@@ -1398,7 +1406,8 @@ static void cdns_mhdp_disable(struct drm_bridge *bridge)
 	cdns_mhdp_reg_write(mhdp, CDNS_DPTX_CAR,
 			    resp & ~(CDNS_VIF_CLK_EN | CDNS_VIF_CLK_RSTN));
 
-	cdns_mhdp_j721e_disable(mhdp);
+	if (mhdp->ops && mhdp->ops->disable)
+		mhdp->ops->disable(mhdp);
 }
 
 static u32 get_training_interval_us(struct cdns_mhdp_device *mhdp,
@@ -1743,7 +1752,8 @@ void cdns_mhdp_enable(struct drm_bridge *bridge)
 
 	dev_dbg(mhdp->dev, "bridge enable\n");
 
-	cdns_mhdp_j721e_enable(mhdp);
+	if (mhdp->ops && mhdp->ops->enable)
+		mhdp->ops->enable(mhdp);
 
 	/* Enable VIF clock for stream 0 */
 	cdns_mhdp_reg_read(mhdp, CDNS_DPTX_CAR, &resp);
@@ -1781,6 +1791,7 @@ static const struct drm_bridge_funcs cdns_mhdp_bridge_funcs = {
 
 static int mhdp_probe(struct platform_device *pdev)
 {
+	const struct of_device_id *match;
 	struct resource *regs;
 	struct cdns_mhdp_device *mhdp;
 	struct clk *clk;
@@ -1824,6 +1835,11 @@ static int mhdp_probe(struct platform_device *pdev)
 
 	clk_prepare_enable(clk);
 
+	match = of_match_device(mhdp_ids, &pdev->dev);
+	if (!match)
+		return -ENODEV;
+	mhdp->ops = (struct mhdp_ops *)match->data;
+
 	pm_runtime_enable(&pdev->dev);
 	ret = pm_runtime_get_sync(&pdev->dev);
 	if (ret < 0) {
@@ -1832,11 +1848,13 @@ static int mhdp_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	ret = cdns_mhdp_j721e_init(mhdp);
-	if (ret != 0) {
-		dev_err(&pdev->dev, "J721E Wrapper initialization failed: %d\n",
-			ret);
-		goto runtime_put;
+	if (mhdp->ops && mhdp->ops->init) {
+		ret = mhdp->ops->init(mhdp);
+		if (ret != 0) {
+			dev_err(&pdev->dev, "MHDP platform initialization failed: %d\n",
+					ret);
+			goto runtime_put;
+		}
 	}
 
 	rate = clk_get_rate(clk);
@@ -1924,6 +1942,9 @@ static int mhdp_remove(struct platform_device *pdev)
 	unsigned int timeout = 10;
 	bool stop_fw = false;
 	int ret = 0;
+
+	if (mhdp->ops && mhdp->ops->exit)
+		mhdp->ops->exit(mhdp);
 
 	drm_bridge_remove(&mhdp->bridge);
 

--- a/drivers/gpu/drm/bridge/cdns-mhdp.h
+++ b/drivers/gpu/drm/bridge/cdns-mhdp.h
@@ -224,6 +224,15 @@ enum mhdp_hw_state { MHDP_HW_INACTIVE = 0, /* HW not initialized */
 		     MHDP_HW_READY,	   /* HW ready, FW active*/
 		     MHDP_HW_STOPPED };	   /* Driver removal FW to be stopped */
 
+struct cdns_mhdp_device;
+
+struct mhdp_ops {
+	int (*init)(struct cdns_mhdp_device *mhdp);
+	void (*exit)(struct cdns_mhdp_device *mhdp);
+	void (*enable)(struct cdns_mhdp_device *mhdp);
+	void (*disable)(struct cdns_mhdp_device *mhdp);
+};
+
 struct cdns_mhdp_device {
 	void __iomem *regs;
 	void __iomem *j721e_regs;
@@ -231,6 +240,8 @@ struct cdns_mhdp_device {
 	struct device *dev;
 	struct clk *clk;
 	struct phy *phy;
+
+	const struct mhdp_ops *ops;
 
 	struct drm_connector connector;
 	struct drm_bridge bridge;


### PR DESCRIPTION
…rations.

Add support for platform specific operations to be called from DP driver
to make it usable in real environments. Operations include init, exit,
enable and disable as a part of struct mhdp_ops. Platform specific
callbacks are selected based on compatible string.

Signed-off-by: Swapnil Jakhade <sjakhade@cadence.com>