### PR TITLE
drm/bridge: cdns-mhdp: Update bus_flags based on compatible string

### DIFF
--- a/drivers/gpu/drm/bridge/cdns-mhdp.h
+++ b/drivers/gpu/drm/bridge/cdns-mhdp.h
@@ -363,6 +363,7 @@ struct cdns_mhdp_device {
 	spinlock_t start_lock;
 	u8 bridge_attached : 1;
 	enum mhdp_hw_state hw_state;
+	enum drm_bus_flags conn_bus_flags_defaults;
 };
 
 


### PR DESCRIPTION
* Add support for display info bus_flags for specific platform
  based on the compatible string.
* Use cdns_mhdp_device structure as parameter instead of using
  separate sink and host structure

Signed-off-by: Yuti Amonkar <yamonkar@cadence.com>